### PR TITLE
Changes the writing of new properties files from mounted volume to co…

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -69,10 +69,10 @@ if [ "$1" = 'bin/catalina.sh' ]; then
                 echo '***********************************************************'
                 echo
 
-                cp -v $METACATUI_BASE_SKIN_PATH/metacatui.properties ${skin_path}/${skin_name}.properties
-                cp -v $METACATUI_BASE_SKIN_PATH/metacatui.properties.metadata.xml ${skin_path}/${skin_name}.properties.metadata.xml
-
                 cp -Rv ${skin_path} ${METACAT_DIR}/style/skins/
+
+                cp -v $METACATUI_BASE_SKIN_PATH/metacatui.properties ${METACAT_DIR}/style/skins/${skin_name}/${skin_name}.properties
+                cp -v $METACATUI_BASE_SKIN_PATH/metacatui.properties.metadata.xml ${METACAT_DIR}/style/skins/${skin_name}/${skin_name}.properties.metadata.xml
 
                 echo
                 echo '**********************************************************'


### PR DESCRIPTION
## Description:
Since data-dev mounts the config volume as a read only mount, it makes more sense to copy the properties files into the skin directory inside metacat dir of the container instead of the config of the mounted volume. 

Issue ess-dive/ess-dive-project#127

Note: It's almost the same earlier PR but I changed the order of the dir copy and where the files are written.