### PR TITLE
Refactor docker-entrypoint.sh to wait for postgres db to be available

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -9,6 +9,15 @@ fi
 
 if [ "$1" = 'bin/catalina.sh' ]; then
 
+    echo
+    echo '**************************************'
+    echo "Waiting for Postgress to start "
+    echo '**************************************'
+    echo
+    while ! nc -z "${DB_HOST:-db}" "${DB_PORT:-5432}"; do
+      sleep 0.1
+    done
+
 
     METACAT_DEFAULT_WAR=/usr/local/tomcat/webapps/metacat.war
     METACAT_DIR=/usr/local/tomcat/webapps/${METACAT_APP_CONTEXT}


### PR DESCRIPTION
# Wait for postgres db to start

## Description
Added while loop to wait for db:5432 to be available.

Closes #16

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Made sure that you can bring an entire stack up successfully and that the metacat container waits for the postgres db to be available.

### Test Configuration
* Metacat Version: 2.12.3
