### PR TITLE
Tomcat9 Upgrade for Metacat 2.12.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:7.0-jre8
+FROM tomcat:9.0-jdk8
 
 # Debian Tomcat UID
 ARG METACAT_UID=108

--- a/image-server.xml
+++ b/image-server.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -26,8 +26,6 @@
   -->
   <!--APR library loader. Documentation at /docs/apr.html -->
   <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on" />
-  <!--Initialize Jasper prior to webapps are loaded. Documentation at /docs/jasper-howto.html -->
-  <Listener className="org.apache.catalina.core.JasperListener" />
   <!-- Prevent memory leaks due to use of particular java/javax APIs-->
   <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
   <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener" />
@@ -63,10 +61,10 @@
 
     <!-- A "Connector" represents an endpoint by which requests are received
          and responses are returned. Documentation at :
-         Java HTTP Connector: /docs/config/http.html (blocking & non-blocking)
+         Java HTTP Connector: /docs/config/http.html
          Java AJP  Connector: /docs/config/ajp.html
          APR (HTTP/AJP) Connector: /docs/apr.html
-         Define a non-SSL HTTP/1.1 Connector on port 8080
+         Define a non-SSL/TLS HTTP/1.1 Connector on port 8080
     -->
     <Connector port="8080" protocol="HTTP/1.1"
                connectionTimeout="20000"
@@ -78,20 +76,49 @@
                connectionTimeout="20000"
                redirectPort="8443" />
     -->
-    <!-- Define a SSL HTTP/1.1 Connector on port 8443
-         This connector uses the BIO implementation that requires the JSSE
-         style configuration. When using the APR/native implementation, the
-         OpenSSL style configuration is required as described in the APR/native
-         documentation -->
+    <!-- Define an SSL/TLS HTTP/1.1 Connector on port 8443
+         This connector uses the NIO implementation. The default
+         SSLImplementation will depend on the presence of the APR/native
+         library and the useOpenSSL attribute of the
+         AprLifecycleListener.
+         Either JSSE or OpenSSL style configuration may be used regardless of
+         the SSLImplementation selected. JSSE style configuration is used below.
+    -->
     <!--
-    <Connector port="8443" protocol="org.apache.coyote.http11.Http11Protocol"
-               maxThreads="150" SSLEnabled="true" scheme="https" secure="true"
-               clientAuth="false" sslProtocol="TLS" />
+    <Connector port="8443" protocol="org.apache.coyote.http11.Http11NioProtocol"
+               maxThreads="150" SSLEnabled="true">
+        <SSLHostConfig>
+            <Certificate certificateKeystoreFile="conf/localhost-rsa.jks"
+                         type="RSA" />
+        </SSLHostConfig>
+    </Connector>
+    -->
+    <!-- Define an SSL/TLS HTTP/1.1 Connector on port 8443 with HTTP/2
+         This connector uses the APR/native implementation which always uses
+         OpenSSL for TLS.
+         Either JSSE or OpenSSL style configuration may be used. OpenSSL style
+         configuration is used below.
+    -->
+    <!--
+    <Connector port="8443" protocol="org.apache.coyote.http11.Http11AprProtocol"
+               maxThreads="150" SSLEnabled="true" >
+        <UpgradeProtocol className="org.apache.coyote.http2.Http2Protocol" />
+        <SSLHostConfig>
+            <Certificate certificateKeyFile="conf/localhost-rsa-key.pem"
+                         certificateFile="conf/localhost-rsa-cert.pem"
+                         certificateChainFile="conf/localhost-rsa-chain.pem"
+                         type="RSA" />
+        </SSLHostConfig>
+    </Connector>
     -->
 
     <!-- Define an AJP 1.3 Connector on port 8009 -->
-    <Connector port="8009" protocol="AJP/1.3" redirectPort="8443" />
-
+    <!--
+    <Connector protocol="AJP/1.3"
+               address="::1"
+               port="8009"
+               redirectPort="8443" />
+    -->
 
     <!-- An Engine represents the entry point (within Catalina) that processes
          every request.  The Engine implementation for Tomcat stand alone
@@ -135,10 +162,11 @@
              Documentation at: /docs/config/valve.html
              Note: The pattern used is equivalent to using pattern="common" -->
         <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
-               prefix="localhost_access_log." suffix=".txt"
+               prefix="localhost_access_log" suffix=".txt"
                pattern="%h %l %u %t &quot;%r&quot; %s %b" />
 
       </Host>
     </Engine>
   </Service>
 </Server>
+

--- a/server.xml
+++ b/server.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -26,8 +26,6 @@
   -->
   <!--APR library loader. Documentation at /docs/apr.html -->
   <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on" />
-  <!--Initialize Jasper prior to webapps are loaded. Documentation at /docs/jasper-howto.html -->
-  <Listener className="org.apache.catalina.core.JasperListener" />
   <!-- Prevent memory leaks due to use of particular java/javax APIs-->
   <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
   <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener" />
@@ -63,10 +61,10 @@
 
     <!-- A "Connector" represents an endpoint by which requests are received
          and responses are returned. Documentation at :
-         Java HTTP Connector: /docs/config/http.html (blocking & non-blocking)
+         Java HTTP Connector: /docs/config/http.html
          Java AJP  Connector: /docs/config/ajp.html
          APR (HTTP/AJP) Connector: /docs/apr.html
-         Define a non-SSL HTTP/1.1 Connector on port 8080
+         Define a non-SSL/TLS HTTP/1.1 Connector on port 8080
     -->
     <Connector port="8080" protocol="HTTP/1.1"
                connectionTimeout="20000"
@@ -78,26 +76,55 @@
                connectionTimeout="20000"
                redirectPort="8443" />
     -->
-    <!-- Define a SSL HTTP/1.1 Connector on port 8443
-         This connector uses the BIO implementation that requires the JSSE
-         style configuration. When using the APR/native implementation, the
-         OpenSSL style configuration is required as described in the APR/native
-         documentation -->
+    <!-- Define an SSL/TLS HTTP/1.1 Connector on port 8443
+         This connector uses the NIO implementation. The default
+         SSLImplementation will depend on the presence of the APR/native
+         library and the useOpenSSL attribute of the
+         AprLifecycleListener.
+         Either JSSE or OpenSSL style configuration may be used regardless of
+         the SSLImplementation selected. JSSE style configuration is used below.
+    -->
     <!--
-    <Connector port="8443" protocol="org.apache.coyote.http11.Http11Protocol"
-               maxThreads="150" SSLEnabled="true" scheme="https" secure="true"
-               clientAuth="false" sslProtocol="TLS" />
+    <Connector port="8443" protocol="org.apache.coyote.http11.Http11NioProtocol"
+               maxThreads="150" SSLEnabled="true">
+        <SSLHostConfig>
+            <Certificate certificateKeystoreFile="conf/localhost-rsa.jks"
+                         type="RSA" />
+        </SSLHostConfig>
+    </Connector>
+    -->
+    <!-- Define an SSL/TLS HTTP/1.1 Connector on port 8443 with HTTP/2
+         This connector uses the APR/native implementation which always uses
+         OpenSSL for TLS.
+         Either JSSE or OpenSSL style configuration may be used. OpenSSL style
+         configuration is used below.
+    -->
+    <!--
+    <Connector port="8443" protocol="org.apache.coyote.http11.Http11AprProtocol"
+               maxThreads="150" SSLEnabled="true" >
+        <UpgradeProtocol className="org.apache.coyote.http2.Http2Protocol" />
+        <SSLHostConfig>
+            <Certificate certificateKeyFile="conf/localhost-rsa-key.pem"
+                         certificateFile="conf/localhost-rsa-cert.pem"
+                         certificateChainFile="conf/localhost-rsa-chain.pem"
+                         type="RSA" />
+        </SSLHostConfig>
+    </Connector>
     -->
 
     <!-- Define an AJP 1.3 Connector on port 8009 -->
-    <Connector port="8009" protocol="AJP/1.3"
-               acceptCount="1000"
+    <Connector protocol="AJP/1.3"
+               address="0.0.0.0"
+               port="8009"
+               redirectPort="8443"
+               acceptCount="1000" 
                acceptorThreadCount="2"
                connectionTimeout="20000"
                maxConnections="10000"
                maxPostSize="-1"
-               maxThreads="500" />
-
+               maxThreads="500"
+               allowedRequestAttributesPattern=".*"
+               secretRequired="false"/>
 
     <!-- An Engine represents the entry point (within Catalina) that processes
          every request.  The Engine implementation for Tomcat stand alone
@@ -131,12 +158,12 @@
       <Host name="localhost"  appBase="webapps"
             unpackWARs="true" autoDeploy="true">
 
+
         <!-- SingleSignOn valve, share authentication between web applications
              Documentation at: /docs/config/valve.html -->
         <!--
         <Valve className="org.apache.catalina.authenticator.SingleSignOn" />
         -->
-
         <!-- Remote IP Valve -->
         <Valve className="org.apache.catalina.valves.RemoteIpValve" requestAttributesEnabled="true" />
 
@@ -145,10 +172,11 @@
              Note: The pattern used is equivalent to using pattern="common" -->
         <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
                requestAttributesEnabled="true"
-               prefix="localhost_access_log." suffix=".txt"
+               prefix="localhost_access_log" suffix=".txt"
                pattern="%a %l %u %t &quot;%r&quot; %s %b" />
 
       </Host>
     </Engine>
   </Service>
 </Server>
+

--- a/server.xml.patch
+++ b/server.xml.patch
@@ -1,33 +1,47 @@
---- image-server.xml	2019-05-31 12:43:29.000000000 -0700
-+++ server.xml	2019-05-31 16:11:30.000000000 -0700
-@@ -90,7 +90,13 @@
+--- image-server.xml	2020-09-10 11:49:53.000000000 -0700
++++ server.xml	2020-09-16 11:08:20.000000000 -0700
+@@ -113,12 +113,18 @@
      -->
  
      <!-- Define an AJP 1.3 Connector on port 8009 -->
--    <Connector port="8009" protocol="AJP/1.3" redirectPort="8443" />
-+    <Connector port="8009" protocol="AJP/1.3"
-+               acceptCount="1000"
+-    <!--
+     <Connector protocol="AJP/1.3"
+-               address="::1"
++               address="0.0.0.0"
+                port="8009"
+-               redirectPort="8443" />
+-    -->
++               redirectPort="8443"
++               acceptCount="1000" 
 +               acceptorThreadCount="2"
 +               connectionTimeout="20000"
 +               maxConnections="10000"
 +               maxPostSize="-1"
-+               maxThreads="500" />
- 
++               maxThreads="500"
++               allowedRequestAttributesPattern=".*"
++               secretRequired="false"/>
  
      <!-- An Engine represents the entry point (within Catalina) that processes
-@@ -131,12 +137,16 @@
+          every request.  The Engine implementation for Tomcat stand alone
+@@ -152,18 +158,22 @@
+       <Host name="localhost"  appBase="webapps"
+             unpackWARs="true" autoDeploy="true">
+ 
++
+         <!-- SingleSignOn valve, share authentication between web applications
+              Documentation at: /docs/config/valve.html -->
+         <!--
          <Valve className="org.apache.catalina.authenticator.SingleSignOn" />
          -->
- 
 +        <!-- Remote IP Valve -->
 +        <Valve className="org.apache.catalina.valves.RemoteIpValve" requestAttributesEnabled="true" />
-+
+ 
          <!-- Access log processes all example.
               Documentation at: /docs/config/valve.html
               Note: The pattern used is equivalent to using pattern="common" -->
          <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
 +               requestAttributesEnabled="true"
-                prefix="localhost_access_log." suffix=".txt"
+                prefix="localhost_access_log" suffix=".txt"
 -               pattern="%h %l %u %t &quot;%r&quot; %s %b" />
 +               pattern="%a %l %u %t &quot;%r&quot; %s %b" />
  


### PR DESCRIPTION
# Tomcat9 Upgrade for Metacat 2.12.3

## Description

As per our discussion with NCEAS, it has been suggested that our version of tomcat be upgraded to either 8 or 9 since those include log rotation capabilities. We can leverage these capabilities to mitigate the size of `catalina.out` which has been collecting all the stdout and stderr from the metacat application. This PR upgrades the docker image of metacat to use the base tomcat:9-jdk8 and includes configuration changes to `conf/server.xml` since changes were made to the AJP connector which metacat uses. 

Implements ess-dive/ess-dive-project#153 



## Type of change

Please delete options that are not relevant.

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Unit tests
- [X] Integration tests 
- [X] Other - add any additional tests here

Testing was done by building the image in `essdive-appstack` and running `./build.sh metacat 2.12.3` to build the image.
Then the changes were deployed using the `ess-dive-catalog`  `provision/docker-compose.yml` file included in that repository. 

Once the services are up, go to `localhost` and check to see that a `503` error does not appear. A `503` error would indicate that metacatui cannot get a connection to metacat. 

After the services are up and metacatui and metacat are connected, run the selenium tests in `ess-dive-catalog`. 

### Test Configuration
* Metacat Version: 2.12.3
* Python Version: 3.7
