### PR TITLE
Rotate catalina.out with logrotate in docker-entrypoint.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         net-tools \
         telnetd \
         procps \
+        logrotate \
     && rm -rf /var/lib/apt/lists/* \
     && cp /tmp/metacat.war /tmp/metacat-index.war /usr/local/tomcat/webapps \
     && cat /tmp/catalina.properties >> /usr/local/tomcat/conf/catalina.properties
+
+ADD metacat.conf /etc/logrotate.d/
 
 COPY apply_config.py /usr/local/bin/
 RUN ln -s usr/local/bin/apply_config.py / # backwards compat

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -18,6 +18,12 @@ if [ "$1" = 'bin/catalina.sh' ]; then
       sleep 0.1
     done
 
+    echo
+    echo '**************************************'
+    echo "Logrotating catalina.out"
+    echo '**************************************'
+    echo
+    /usr/sbin/logrotate -s /usr/local/tomcat/logs/logrotate-status.log /etc/logrotate.d/metacat.conf
 
     METACAT_DEFAULT_WAR=/usr/local/tomcat/webapps/metacat.war
     METACAT_DIR=/usr/local/tomcat/webapps/${METACAT_APP_CONTEXT}
@@ -111,7 +117,6 @@ if [ "$1" = 'bin/catalina.sh' ]; then
     if [  ! -z "$ADMINPASS_FILE"  ] && [ -s $ADMINPASS_FILE ];then
         ADMINPASS=`cat $ADMINPASS_FILE`
     fi
-
 
     # Look for the properties file
     if [ -s $APP_PROPERTIES_FILE ];

--- a/metacat.conf
+++ b/metacat.conf
@@ -1,0 +1,8 @@
+/usr/local/tomcat/logs/catalina.out {
+    copytruncate
+    rotate 12
+    compress
+    missingok
+    size 100M
+    dateext
+}


### PR DESCRIPTION
# Rotate catalina.out with logrotate

## Description
Closes ess-dive/ess-dive-project#155

Logrotates catalina.out by using the docker-entrypoint.sh file and
executing logrotate upon container start-up. This mounts a configuration
file into the container that logrotate will use for rotation settings.

Due to the bugs present in DailyLogRollingFile - documented here:
https://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/DailyRollingFileAppender.html

It is recommended to use an appender from log4j extras. This causes
additional maintenance overhead. Rather than modifying log4j.properties
files for metacat and metacat-index, the defaults are kept and the
logrotation is done only in `catalina.out`.

## Type of change

Please delete options that are not relevant.
- [X] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unit tests
- [ ] Integration tests 
- [ ] Test coverage >= 77%
- [ ] Flake8 Tests 
- [ ] Mypy Tests 
- [X] Other - add any additional tests here

Tested by building the image and running the entire application stack using `ess-dive-catalog` repository

### Test Configuration
* Metacat Version: 2.12.3
* Python Version: 3.7
