### PR TITLE
Make logrotate a background process

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -23,7 +23,7 @@ if [ "$1" = 'bin/catalina.sh' ]; then
     echo "Logrotating catalina.out"
     echo '**************************************'
     echo
-    /usr/sbin/logrotate -s /usr/local/tomcat/logs/logrotate-status.log /etc/logrotate.d/metacat.conf
+    /usr/sbin/logrotate -s /usr/local/tomcat/logs/logrotate-status.log /etc/logrotate.d/metacat.conf &
 
     METACAT_DEFAULT_WAR=/usr/local/tomcat/webapps/metacat.war
     METACAT_DIR=/usr/local/tomcat/webapps/${METACAT_APP_CONTEXT}


### PR DESCRIPTION
# Background logrotate process

## Description

Closes #22

This runs logrotate as a background process rather than in the
foreground. Degradation was caused by a delay in container startup when
catalina.out gets rotated. If the file is big enough, the delay can be
significant to cause degradation.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Other - add any additional tests here

Testing is done by doing the following: 

stop any existing metacat containers/processes in the case of Spin run this using `ess-dive-config`:

`./deploy.sh dev stop data-dev-ess-dive-lbl/app-metacat`

then check if catalina.out is big enough on the community file system located on Cori: 
`ls -lah $CFS/m2690/ess-dive/metacat/usr/local/tomcat/logs/catalina.out`

if it is less than 100M then make it bigger by using `truncate`: 

`truncate -s 200M catalina.out` 

Then restart the container using the built image with the commit number `p57`. So modify the `docker-compose.yml` file in `ess-dive-config`. You'll have to build the image and push to the spin registry using the `essdive-appstack` repository. 

`./deploy.sh dev up -d app-metacat`

Then check for the following: 
1. private packages are visible
2. new data can be submitted
3. catalina.out gets logrotated.

Note: You will have to delete one of the old tarballs if they already exist since logrotate will check for the existence of that tarball. If it already exists then no logrotation will happen. 


### Test Configuration
* Metacat Version: 2.12.3
* Python Version: 3.7.4
