### PR TITLE
Add contentURL to distribution elements in JSON-LD

### DIFF
--- a/metacat/skins/json-ld/eml2jsonld.xsl
+++ b/metacat/skins/json-ld/eml2jsonld.xsl
@@ -13,6 +13,7 @@
     <xsl:param name="catalogURL"><![CDATA[https://]]><xsl:value-of select="$serverName" /></xsl:param>
     <xsl:param name="viewURL"><xsl:value-of select="$catalogURL"/><![CDATA[/view]]></xsl:param>
     <xsl:param name="url"><xsl:value-of select="$viewURL" /><![CDATA[/]]><xsl:value-of select="$pid" /></xsl:param>
+    <xsl:param name="objectURL"><xsl:value-of select="$catalogURL" /><![CDATA[/catalog/d1/mn/v2/object]]></xsl:param>
 
     <xsl:template match="@* | node()">
 
@@ -275,9 +276,11 @@
         <xsl:if test="dataset/otherEntity">
             ,"distribution": [
             <xsl:for-each select="dataset/otherEntity">
-                {"name":"<xsl:value-of select="entityName"/>",
+                {"@type":"DataDownload",
+                "name":"<xsl:value-of select="entityName"/>",
                 "encodingFormat":"<xsl:value-of select="entityType"/>"<xsl:if test="@id">,
-                "identifier": "<xsl:value-of select="@id"/>"
+                "identifier": "<xsl:value-of select="@id"/>",
+                "contentUrl": "<xsl:value-of select="$objectURL" /><![CDATA[/]]><xsl:value-of select="@id"/>"
                 </xsl:if>}
                 <xsl:if test="position() != last()">
                     <xsl:text>,</xsl:text>


### PR DESCRIPTION
Closes ess-dive/ess-dive-catalog#415

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Other - Built and deployed metacat image to data-test3 and confirmed that the `contentUrl` shows up in the json-ld view. See https://data-test3.ess-dive.lbl.gov/catalog/d1/mn/v2/views/json-ld/ess-dive-2b878a83491af99-20210830T190526171

### Test Configuration
* Metacat Version: 2.14.1
