### PR TITLE
Upgrade metacat with enhancements to support external data linking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.war
 .DS_Store
 image_version.yml
+metacat/skins/metacatui
+style

--- a/build.sh
+++ b/build.sh
@@ -90,11 +90,17 @@ then
   docker build ${DOCKER_BUILD_OPTIONS} -f $DIR/metacat/Dockerfile -t ${IMAGE_NAME} $BUILD_ARGS $DIR/
 
 
-  rm -rf $DIR/metacat-index.war $DIR/solr/WEB-INF
+  rm -rf $DIR/metacat-index.war $DIR/metacat.war $DIR/solr/WEB-INF "$DIR/style/skins/metacatui/eml-2/eml-dataset.xsl"
 
   # Get the solr config from the index war file for solr image
   tar -xvf  $DIR/${ARCHIVE} --directory $DIR metacat-index.war
+  tar -xvf  $DIR/${ARCHIVE} --directory $DIR metacat.war
   unzip "$DIR/metacat-index.war" "WEB-INF/classes/solr-home/conf/*" -d "$DIR/solr"
+
+  # Patch eml-dataset.xsl with eml-dataset.xsl.patch for the current release
+  unzip "$DIR/metacat.war" "style/skins/metacatui/eml-2/eml-dataset.xsl"   -d "$DIR"
+  [ ! -f "$DIR/metacat/skins/metacatui/eml-2/" ] && mkdir -pv "$DIR/metacat/skins/metacatui/eml-2/"
+  patch -N $DIR/style/skins/metacatui/eml-2/eml-dataset.xsl  $DIR/metacat/eml-dataset.xsl.patch -o $DIR/metacat/skins/metacatui/eml-2/eml-dataset.xsl
 
   # create the docker tag
   DOCKER_TAG="${VERSION}-${SOLR_VERSION}-p$(cd $DIR; git rev-list HEAD --count)"

--- a/metacat/Dockerfile
+++ b/metacat/Dockerfile
@@ -53,6 +53,7 @@ RUN patch conf/server.xml /tmp/server.xml.patch
 RUN groupadd -g ${METACAT_GID} metacat && \
     useradd -u ${METACAT_UID} -g ${METACAT_GID} -c 'Metacat User'  --no-create-home metacat && \
     mkdir -p /var/metacat && \
+    chown -R metacat:metacat /tmp/skins && \
     chown -R metacat:metacat /var/metacat logs temp work && \
     chown -R metacat:metacat /usr/local/tomcat/conf && \
     chown metacat:metacat /usr/local/tomcat/webapps  && \

--- a/metacat/docker-entrypoint.sh
+++ b/metacat/docker-entrypoint.sh
@@ -94,12 +94,16 @@ if [ "$1" = 'bin/catalina.sh' ]; then
                 echo '**********************************************************'
                 echo "Copying base metacat skin properties files into ${skin_path}"
                 echo '***********************************************************'
-                echo
 
                 cp -Rv ${skin_path} ${METACAT_DIR}/style/skins/
 
-                cat $METACATUI_BASE_SKIN_PATH/metacatui.properties >> ${METACAT_DIR}/style/skins/${skin_name}/${skin_name}.properties
-                cp -v $METACATUI_BASE_SKIN_PATH/metacatui.properties.metadata.xml ${METACAT_DIR}/style/skins/${skin_name}/${skin_name}.properties.metadata.xml
+                if [ ! -f ${METACAT_DIR}/style/skins/${skin_name}/${skin_name}.properties ]; then
+                  cat $METACATUI_BASE_SKIN_PATH/metacatui.properties >> ${METACAT_DIR}/style/skins/${skin_name}/${skin_name}.properties
+                fi
+
+                if [ ! -f ${METACAT_DIR}/style/skins/${skin_name}/${skin_name}.properties.metadata.xml ]; then
+                  cp -v $METACATUI_BASE_SKIN_PATH/metacatui.properties.metadata.xml ${METACAT_DIR}/style/skins/${skin_name}/${skin_name}.properties.metadata.xml
+                fi
 
                 echo
                 echo '**********************************************************'

--- a/metacat/eml-dataset.xsl.patch
+++ b/metacat/eml-dataset.xsl.patch
@@ -1,0 +1,89 @@
+--- ./style/skins/metacatui/eml-2/eml-dataset.xsl	2021-03-15 17:27:26.000000000 -0700
++++ metacat/skins/metacatui/eml-2/eml-dataset.xsl	2021-09-21 10:12:14.000000000 -0700
+@@ -60,22 +60,71 @@
+ 		<xsl:call-template name="datasetcitation" />
+     </xsl:for-each>
+ 
++    <xsl:if test="annotation[propertyURI[contains(text(),'relationtype')]]">
++        <h4>External Links to Data or Metadata</h4>
++        <div class="control-group">
++            <div class="controls-well">
++                <table class="table table-striped table-condensed">
++                    <thead>
++                        <tr>
++                        <th colspan="3" class="table-header">External links for this dataset</th>
++                        </tr>
++                        <tr>
++                            <th>Label</th>
++                            <th>URL</th>
++                            <th>Relationship</th>
++                        </tr>
++                    </thead>
++                    <tbody>
++                    <xsl:for-each select="annotation[propertyURI[contains(text(),'relationtype')]]">
++                        <tr>
++                            <td><xsl:value-of select="valueURI/@label"/></td>
++                            <td><xsl:element name="a">
++                                <xsl:attribute name="href"><xsl:value-of select="normalize-space(valueURI)"/></xsl:attribute>
++                                <xsl:attribute name="target">_blank</xsl:attribute>
++                                <xsl:value-of select="valueURI"/>
++                            </xsl:element></td>
++                            <td>
++                            <xsl:choose>
++                                <xsl:when test="propertyURI[@label='has part']">
++                                     Distributed as part of this data package.
++                                </xsl:when>
++                                <xsl:when test="propertyURI[@label='is identical to']">
++                                     Same as this data package where the original data can be found.
++                                </xsl:when>
++                                <xsl:when test="propertyURI[@label='is original form of']">
++                                     Copy of the data in this data package.
++                                </xsl:when>
++                                <xsl:otherwise>
++                                    Data package <xsl:value-of select="propertyURI/@label"/> this data.
++                                </xsl:otherwise>
++                            </xsl:choose>
++                            </td>
++                        </tr>
++                    </xsl:for-each>
++                    </tbody>
++                    </table>
++            </div>
++        </div>
++    </xsl:if>
++
++    <xsl:if test="annotations/propertyURI[not(contains(text(),'relationtype'))]]">
++    <div class="control-group">
++    <label class="control-label">
++        Annotations
++        <xsl:call-template name="annotation-info-tooltip" />
++    </label>
++    <div class="controls controls-well annotations-container">
++        <xsl:for-each select="annotation">
++        <xsl:call-template name="annotation">
++            <xsl:with-param name="context" select="concat('Dataset &lt;strong&gt;', ../@packageId, '&lt;/strong&gt;')" />
++        </xsl:call-template>
++        </xsl:for-each>
++    </div>
++    </div>
++    </xsl:if>
++
+      <h4>General</h4>
+-			<xsl:if test="annotation">
+-				<div class="control-group">
+-				<label class="control-label">
+-					Annotations
+-					<xsl:call-template name="annotation-info-tooltip" />
+-				</label>
+-				<div class="controls controls-well annotations-container">
+-					<xsl:for-each select="annotation">
+-					<xsl:call-template name="annotation">
+-						<xsl:with-param name="context" select="concat('Dataset &lt;strong&gt;', ../@packageId, '&lt;/strong&gt;')" />
+-					</xsl:call-template>
+-					</xsl:for-each>
+-				</div>
+-				</div>
+-			</xsl:if>
+ 
+              <!-- put in the title -->
+              <xsl:if test="./title">

--- a/metacat/skins/json-ld/eml2jsonld.xsl
+++ b/metacat/skins/json-ld/eml2jsonld.xsl
@@ -28,6 +28,56 @@
         "url": "<xsl:value-of select="$url"/>",
         "@type": "Dataset",
         "@id": "<xsl:value-of select="$url"/>",
+                <xsl:if test="dataset/annotation[propertyURI/@label='is identical to']">
+        "identifier": [<xsl:for-each select="dataset/annotation[propertyURI/@label='is identical to']">
+            {
+                "@type": "PropertyValue",
+                "propertyID": "DOI",
+                "value": "<xsl:call-template name="transform-string"><xsl:with-param name="content" select="valueURI/@label"/></xsl:call-template>"
+            }<xsl:if test="position() != last()">
+                <xsl:text>,</xsl:text>
+            </xsl:if>
+            </xsl:for-each>
+            ],
+        "sameAs": [<xsl:for-each select="dataset/annotation[propertyURI/@label='is identical to']">
+            "<xsl:call-template name="transform-string"><xsl:with-param name="content" select="valueURI"/></xsl:call-template>"<xsl:if test="position() != last()">
+                <xsl:text>,</xsl:text>
+            </xsl:if>
+            </xsl:for-each>
+            ],</xsl:if>
+        <xsl:if test="dataset/annotation[propertyURI/@label='is original form of']">
+        "archivedAt": [<xsl:for-each select="dataset/annotation[propertyURI/@label='is original form of']">
+            {
+                "@type": "WebPage",
+                "name": "<xsl:value-of select="valueURI/@label"/>",
+                "url": "<xsl:call-template name="transform-string"><xsl:with-param name="content" select="valueURI"/></xsl:call-template>"
+            }<xsl:if test="position() != last()">
+                <xsl:text>,</xsl:text>
+            </xsl:if>
+            </xsl:for-each>
+        ],</xsl:if>
+        <xsl:if test="dataset/annotation[propertyURI/@label='is derived from']">
+        "isBasedOn": [<xsl:for-each select="dataset/annotation[propertyURI/@label='is derived from']">
+            {
+                "@type": "Dataset",
+                "@id": "<xsl:value-of select="valueURI/@label"/>",
+                "url": "<xsl:call-template name="transform-string"><xsl:with-param name="content" select="valueURI"/></xsl:call-template>"
+            }<xsl:if test="position() != last()">
+                <xsl:text>,</xsl:text>
+            </xsl:if>
+            </xsl:for-each>
+        ],</xsl:if>
+        <xsl:if test="dataset/annotation[propertyURI/@label='has part']">
+        "hasPart": [<xsl:for-each select="dataset/annotation[propertyURI/@label='has part']">
+            {
+                "@type": "WebPage",
+                "name": "<xsl:value-of select="valueURI/@label"/>",
+                "url": "<xsl:call-template name="transform-string"><xsl:with-param name="content" select="valueURI"/></xsl:call-template>"
+            }<xsl:if test="position() != last()">
+                <xsl:text>,</xsl:text>
+            </xsl:if>
+            </xsl:for-each>
+            ],</xsl:if>
         "name": "<xsl:call-template name="transform-string"><xsl:with-param name="content" select="dataset/title"/></xsl:call-template>",
         "includedInDataCatalog": { "name": "<xsl:value-of select="$catalogName"/>",
                                    "url": "<xsl:value-of select="$catalogURL"/>",
@@ -104,7 +154,7 @@
         </xsl:if>
         <xsl:if test="dataset/pubDate">"datePublished": "<xsl:call-template name="transform-string"><xsl:with-param name="content" select="dataset/pubDate"/></xsl:call-template>",</xsl:if>
         "keywords": [
-        <xsl:for-each select="dataset/keywordSet[keywordThesaurus[contains(text(),'CATEGORICAL')]]">
+        <xsl:for-each select="dataset/keywordSet[keywordThesaurus[contains(text(),'CATEGORICAL')] or not(keywordThesaurus)]">
             <xsl:for-each select="keyword">
                 "<xsl:call-template name="transform-string"><xsl:with-param name="content" select="."/></xsl:call-template>"
                 <xsl:if test="position() != last()">
@@ -283,7 +333,7 @@
                 "contentUrl": "<xsl:value-of select="$objectURL" /><![CDATA[/]]><xsl:value-of select="@id"/>"
                 </xsl:if>}
                 <xsl:if test="position() != last()">
-                    <xsl:text>,</xsl:text>
+                <xsl:text>,</xsl:text>
                 </xsl:if>
             </xsl:for-each>
             ]


### PR DESCRIPTION
Enhances metacat build to patch the metacatui dataset XSL
to render external linking annotations in a separate
table.  Addtionally, updates the json-ld view to transform
relation type annotations to `Dataset.hasPart`, `Dataset.archivedAt`,
`Dataset.sameAs` and `Dataset.identifier`
    
This modification pulls the latest eml-dataset.xsl from the
Metacat release patches it with eml-dataset.xsl.patch.
    
Closes ess-dive/ess-dive-project#196
Issue ess-dive/essdive-toolset#218


## Type of change

- [X] New feature (non-breaking change which adds functionality)

